### PR TITLE
Add options to :named clause

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metabase/mbql "1.1.0"
+(defproject metabase/mbql "1.2.0-SNAPSHOT"
   :description "Shared things used across several Metabase projects, such as i18n and config."
   :url "https://github.com/metabase/mbql"
   :min-lein-version "2.5.0"
@@ -26,7 +26,7 @@
   :profiles
   {:dev
    {:dependencies
-    [[org.clojure/clojure "1.10.0"]
+    [[org.clojure/clojure "1.10.1"]
      [expectations "2.2.0-beta2"]]
 
     :injections

--- a/src/metabase/mbql/normalize.clj
+++ b/src/metabase/mbql/normalize.clj
@@ -153,8 +153,8 @@
 
     ;; named aggregation ([:named <ag> <name>])
     (is-clause? :named ag-clause)
-    (let [[_ ag ag-name] ag-clause]
-      [:named (normalize-ag-clause-tokens ag) ag-name])
+    (let [[_ wrapped-ag & more] ag-clause]
+      (into [:named (normalize-ag-clause-tokens wrapped-ag)] more))
 
     ;; something wack like {:aggregations [:count [:sum 10]]} or {:aggregations [:count :count]}
     (when (mbql-clause? ag-clause)
@@ -319,11 +319,8 @@
                                            (map (comp canonicalize-mbql-clauses canonicalize-filter)
                                                 args))))
 
-    [(filter-name :guard #{:starts-with :ends-with :contains :does-not-contain}) field arg options]
-    [filter-name (wrap-implicit-field-id field) arg options]
-
-    [(filter-name :guard #{:starts-with :ends-with :contains :does-not-contain}) field arg]
-    [filter-name (wrap-implicit-field-id field) arg]
+    [(filter-name :guard #{:starts-with :ends-with :contains :does-not-contain}) & more]
+    (into [filter-name (wrap-implicit-field-id field)] more)
 
     [:inside field-1 field-2 & coordinates]
     (vec
@@ -357,8 +354,8 @@
     nil
 
     ;; For named aggregations (`[:named <ag> <name>]`) we want to leave as-is and just canonicalize the ag it names
-    [:named ag ag-name]
-    [:named (canonicalize-aggregation-subclause ag) ag-name]
+    [:named wrapped-ag & more]
+    (into [:named (canonicalize-aggregation-subclause wrapped-ag)] more)
 
     [(ag-type :guard #{:+ :- :* :/}) & args]
     (apply

--- a/src/metabase/mbql/normalize.clj
+++ b/src/metabase/mbql/normalize.clj
@@ -319,7 +319,7 @@
                                            (map (comp canonicalize-mbql-clauses canonicalize-filter)
                                                 args))))
 
-    [(filter-name :guard #{:starts-with :ends-with :contains :does-not-contain}) & more]
+    [(filter-name :guard #{:starts-with :ends-with :contains :does-not-contain}) field & more]
     (into [filter-name (wrap-implicit-field-id field)] more)
 
     [:inside field-1 field-2 & coordinates]

--- a/src/metabase/mbql/schema.clj
+++ b/src/metabase/mbql/schema.clj
@@ -516,7 +516,19 @@
 ;; any sort of aggregation can be wrapped in a `[:named <ag> <custom-name>]` clause, but you cannot wrap a `:named` in
 ;; a `:named`
 
-(defclause named, aggregation UnnamedAggregation, aggregation-name su/NonBlankString)
+(def NamedAggregationOptions
+  "Schema for optional options map for the `:named` aggregation clause."
+  ;; whether the supplied name should be used as the user-facing display name of the aggregation as well. `true` by
+  ;; default -- this is what we want to do if the `:named` clause was generated in the FE with a user-supplied name.
+  ;; If this clause is used internally to deduplicate/uniquify aggregation names (e.g. `sum` and `sum_2`, we should
+  ;; set this to `false` so we can try to come up with a good name for the aggregation it wraps (e.g. `sum of My
+  ;; Field`)
+  {(s/optional-key :use-as-display-name?) s/Bool}) ; default true
+
+(defclause named
+  aggregation      UnnamedAggregation
+  aggregation-name su/NonBlankString
+  options          (optional NamedAggregationOptions))
 
 (def Aggregation
   "Schema for anything that is a valid `:aggregation` clause."

--- a/src/metabase/mbql/util.clj
+++ b/src/metabase/mbql/util.clj
@@ -488,10 +488,11 @@
 (s/defn uniquify-named-aggregations :- NamedAggregationsWithUniqueNames
   "Make the names of a sequence of named aggregations unique by adding suffixes such as `_2`."
   [named-aggregations :- [mbql.s/named]]
-  (map (fn [[_ ag] unique-name]
-         [:named ag unique-name])
+  (map (fn [original-clause unique-name]
+         (assoc (vec original-clause) 2 unique-name))
        named-aggregations
-       (uniquify-names (map last named-aggregations))))
+       (uniquify-names
+        (map #(nth % 2) named-aggregations))))
 
 (s/defn pre-alias-aggregations :- [mbql.s/named]
   "Wrap every aggregation clause in a `:named` clause, using the name returned by `(aggregation->name-fn ag-clause)`

--- a/src/metabase/mbql/util.clj
+++ b/src/metabase/mbql/util.clj
@@ -507,8 +507,11 @@
   {:style/indent 1}
   [aggregation->name-fn :- (s/pred fn?), aggregations :- [mbql.s/Aggregation]]
   (replace aggregations
-    [:named ag ag-name]       [:named ag ag-name]
-    [(_ :guard keyword?) & _] [:named &match (aggregation->name-fn &match)]))
+    :named
+    &match
+
+    [(_ :guard keyword?) & _]
+    [:named &match (aggregation->name-fn &match) {:use-as-display-name? false}]))
 
 (s/defn pre-alias-and-uniquify-aggregations :- NamedAggregationsWithUniqueNames
   "Wrap every aggregation clause in a `:named` clause with a unique name. Combines `pre-alias-aggregations` with

--- a/test/metabase/mbql/normalize_test.clj
+++ b/test/metabase/mbql/normalize_test.clj
@@ -112,7 +112,8 @@
 
 (expect
   {:query {:aggregation [:named [:sum 10] "My COOL AG" {:use-as-display-name? false}]}}
-  (#'normalize/normalize-tokens {:query {:aggregation ["named" ["SuM" 10] "My COOL AG" {:use-as-display-name? false}]}}))
+  (#'normalize/normalize-tokens
+   {:query {:aggregation ["named" ["SuM" 10] "My COOL AG" {:use-as-display-name? false}]}}))
 
 ;; try an expression ag
 (expect

--- a/test/metabase/mbql/normalize_test.clj
+++ b/test/metabase/mbql/normalize_test.clj
@@ -110,10 +110,14 @@
   {:query {:aggregation [:named [:sum 10] "My COOL AG"]}}
   (#'normalize/normalize-tokens {:query {:aggregation ["named" ["SuM" 10] "My COOL AG"]}}))
 
+(expect
+  {:query {:aggregation [:named [:sum 10] "My COOL AG" {:use-as-display-name? false}]}}
+  (#'normalize/normalize-tokens {:query {:aggregation ["named" ["SuM" 10] "My COOL AG" {:use-as-display-name? false}]}}))
+
 ;; try an expression ag
 (expect
-  {:query {:aggregation [:+ [:sum 10] [:* [:sum 20] 3]]}}
-  (#'normalize/normalize-tokens {:query {:aggregation ["+" ["sum" 10] ["*" ["SUM" 20] 3]]}}))
+ {:query {:aggregation [:+ [:sum 10] [:* [:sum 20] 3]]}}
+ (#'normalize/normalize-tokens {:query {:aggregation ["+" ["sum" 10] ["*" ["SUM" 20] 3]]}}))
 
 ;; expression ags should handle varargs
 (expect
@@ -456,10 +460,14 @@
   {:query {:aggregation [[:named [:sum [:field-id 10]] "Sum *TEN*"]]}}
   (#'normalize/canonicalize {:query {:aggregation [:named [:sum 10] "Sum *TEN*"]}}))
 
+(expect
+  {:query {:aggregation [[:named [:sum [:field-id 10]] "Sum *TEN*" {:use-as-display-name? false}]]}}
+  (#'normalize/canonicalize {:query {:aggregation [:named [:sum 10] "Sum *TEN*" {:use-as-display-name? false}]}}))
+
 ;; make sure expression aggregations work correctly
 (expect
-  {:query {:aggregation [[:+ [:sum [:field-id 10]] 2]]}}
-  (#'normalize/canonicalize {:query {:aggregation [:+ [:sum 10] 2]}}))
+ {:query {:aggregation [[:+ [:sum [:field-id 10]] 2]]}}
+ (#'normalize/canonicalize {:query {:aggregation [:+ [:sum 10] 2]}}))
 
 (expect
   {:query {:aggregation [[:+ [:sum [:field-id 10]] [:* [:sum [:field-id 20]] [:sum [:field-id 30]]]]]}}

--- a/test/metabase/mbql/util_test.clj
+++ b/test/metabase/mbql/util_test.clj
@@ -618,12 +618,12 @@
   (name ag-name))
 
 (expect
-  [[:named [:sum [:field-id 1]] "sum"]
-   [:named [:count [:field-id 1]] "count"]
-   [:named [:sum [:field-id 1]] "sum"]
-   [:named [:avg [:field-id 1]] "avg"]
-   [:named [:sum [:field-id 1]] "sum"]
-   [:named [:min [:field-id 1]] "min"]]
+  [[:named [:sum [:field-id 1]]   "sum"   {:use-as-display-name? false}]
+   [:named [:count [:field-id 1]] "count" {:use-as-display-name? false}]
+   [:named [:sum [:field-id 1]]   "sum"   {:use-as-display-name? false}]
+   [:named [:avg [:field-id 1]]   "avg"   {:use-as-display-name? false}]
+   [:named [:sum [:field-id 1]]   "sum"   {:use-as-display-name? false}]
+   [:named [:min [:field-id 1]]   "min"   {:use-as-display-name? false}]]
   (mbql.u/pre-alias-aggregations simple-ag->name
     [[:sum [:field-id 1]]
      [:count [:field-id 1]]
@@ -634,12 +634,12 @@
 
 ;; we shouldn't change the name of ones that are already named
 (expect
-  [[:named [:sum [:field-id 1]] "sum"]
-   [:named [:count [:field-id 1]] "count"]
-   [:named [:sum [:field-id 1]] "sum"]
-   [:named [:avg [:field-id 1]] "avg"]
-   [:named [:sum [:field-id 1]] "sum_2"]
-   [:named [:min [:field-id 1]] "min"]]
+  [[:named [:sum [:field-id 1]]   "sum"   {:use-as-display-name? false}]
+   [:named [:count [:field-id 1]] "count" {:use-as-display-name? false}]
+   [:named [:sum [:field-id 1]]   "sum"   {:use-as-display-name? false}]
+   [:named [:avg [:field-id 1]]   "avg"   {:use-as-display-name? false}]
+   [:named [:sum [:field-id 1]]   "sum_2"]
+   [:named [:min [:field-id 1]]   "min"   {:use-as-display-name? false}]]
   (mbql.u/pre-alias-aggregations simple-ag->name
     [[:sum [:field-id 1]]
      [:count [:field-id 1]]
@@ -650,12 +650,12 @@
 
 ;; ok, can we do the same thing as the tests above but make those names *unique* at the same time?
 (expect
-  [[:named [:sum [:field-id 1]] "sum"]
-   [:named [:count [:field-id 1]] "count"]
-   [:named [:sum [:field-id 1]] "sum_2"]
-   [:named [:avg [:field-id 1]] "avg"]
-   [:named [:sum [:field-id 1]] "sum_3"]
-   [:named [:min [:field-id 1]] "min"]]
+  [[:named [:sum [:field-id 1]]   "sum"   {:use-as-display-name? false}]
+   [:named [:count [:field-id 1]] "count" {:use-as-display-name? false}]
+   [:named [:sum [:field-id 1]]   "sum_2" {:use-as-display-name? false}]
+   [:named [:avg [:field-id 1]]   "avg"   {:use-as-display-name? false}]
+   [:named [:sum [:field-id 1]]   "sum_3" {:use-as-display-name? false}]
+   [:named [:min [:field-id 1]]   "min"   {:use-as-display-name? false}]]
   (mbql.u/pre-alias-and-uniquify-aggregations simple-ag->name
     [[:sum [:field-id 1]]
      [:count [:field-id 1]]
@@ -665,12 +665,12 @@
      [:min [:field-id 1]]]))
 
 (expect
-  [[:named [:sum [:field-id 1]] "sum"]
-   [:named [:count [:field-id 1]] "count"]
-   [:named [:sum [:field-id 1]] "sum_2"]
-   [:named [:avg [:field-id 1]] "avg"]
-   [:named [:sum [:field-id 1]] "sum_2_2"]
-   [:named [:min [:field-id 1]] "min"]]
+  [[:named [:sum [:field-id 1]]   "sum"     {:use-as-display-name? false}]
+   [:named [:count [:field-id 1]] "count"   {:use-as-display-name? false}]
+   [:named [:sum [:field-id 1]]   "sum_2"   {:use-as-display-name? false}]
+   [:named [:avg [:field-id 1]]   "avg"     {:use-as-display-name? false}]
+   [:named [:sum [:field-id 1]]   "sum_2_2"]
+   [:named [:min [:field-id 1]]   "min"     {:use-as-display-name? false}]]
   (mbql.u/pre-alias-and-uniquify-aggregations simple-ag->name
     [[:sum [:field-id 1]]
      [:count [:field-id 1]]

--- a/test/metabase/mbql/util_test.clj
+++ b/test/metabase/mbql/util_test.clj
@@ -679,13 +679,29 @@
      [:named [:sum [:field-id 1]] "sum_2"]
      [:min [:field-id 1]]]))
 
+;; `pre-alias-and-uniquify-aggregations` shouldn't stomp over existing options
+(expect
+ [[:named [:sum [:field-id 1]]   "sum"     {:use-as-display-name? false}]
+  [:named [:count [:field-id 1]] "count"   {:use-as-display-name? false}]
+  [:named [:sum [:field-id 1]]   "sum_2"   {:use-as-display-name? true}]
+  [:named [:avg [:field-id 1]]   "avg"     {:use-as-display-name? true}]
+  [:named [:sum [:field-id 1]]   "sum_2_2" {:use-as-display-name? true}]
+  [:named [:min [:field-id 1]]   "min"     {:use-as-display-name? false}]]
+ (mbql.u/pre-alias-and-uniquify-aggregations simple-ag->name
+   [[:sum [:field-id 1]]
+    [:count [:field-id 1]]
+    [:named [:sum [:field-id 1]] "sum"   {:use-as-display-name? true}]
+    [:named [:avg [:field-id 1]] "avg"   {:use-as-display-name? true}]
+    [:named [:sum [:field-id 1]] "sum_2" {:use-as-display-name? true}]
+    [:min [:field-id 1]]]))
+
 ;;; --------------------------------------------- query->max-rows-limit ----------------------------------------------
 
 ;; should return `:limit` if set
 (expect
-  10
-  (mbql.u/query->max-rows-limit
-   {:database 1, :type :query, :query {:source-table 1, :limit 10}}))
+ 10
+ (mbql.u/query->max-rows-limit
+  {:database 1, :type :query, :query {:source-table 1, :limit 10}}))
 
 ;; should return `:page` items if set
 (expect


### PR DESCRIPTION
`:named` clause can now either be

```clj
[:named aggregation "ag name"]
```

or 
```clj
[:named aggregation "ag name" options]
```

where options is a map that currently accepts the following keys:

```clj
;; whether the supplied name should be used as the user-facing display name of the aggregation as well. `true` by
;; default -- this is what we want to do if the `:named` clause was generated in the FE with a user-supplied name.
;; If this clause is used internally to deduplicate/uniquify aggregation names (e.g. `sum` and `sum_2`, we should
;; set this to `false` so we can try to come up with a good name for the aggregation it wraps (e.g. `sum of My
;; Field`)
  {(s/optional-key :use-as-display-name?) s/Bool}) ; default true
```

This is needed so we can differentiate between `:named` clauses generated internally by the QP (which should still get auto-generated display names, like `sum of Field`) and ones explicitly specified by the user (which should always be used as the display name, like `My Renamed Field`)