### PR TITLE
Replace `:named` aggregation clause with more general `:aggregation-options`

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metabase/mbql "1.2.0"
+(defproject metabase/mbql "1.3.0-SNAPSHOT"
   :description "Shared things used across several Metabase projects, such as i18n and config."
   :url "https://github.com/metabase/mbql"
   :min-lein-version "2.5.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metabase/mbql "1.3.0-SNAPSHOT"
+(defproject metabase/mbql "1.3.0"
   :description "Shared things used across several Metabase projects, such as i18n and config."
   :url "https://github.com/metabase/mbql"
   :min-lein-version "2.5.0"
@@ -19,8 +19,8 @@
   :dependencies
   [[org.clojure/core.match "0.3.0"]
    [medley "1.2.0"]
-   [metabase/common "1.0.2"]
-   [metabase/schema-util "1.0.1"]
+   [metabase/common "1.0.4"]
+   [metabase/schema-util "1.0.2"]
    [prismatic/schema "1.1.11"]]
 
   :profiles

--- a/src/metabase/mbql/schema.clj
+++ b/src/metabase/mbql/schema.clj
@@ -513,27 +513,21 @@
 (def ^:private UnnamedAggregation
   (s/recursive #'UnnamedAggregation*))
 
-;; any sort of aggregation can be wrapped in a `[:named <ag> <custom-name>]` clause, but you cannot wrap a `:named` in
-;; a `:named`
+(def AggregationOptions
+  "Additional options for any aggregation clause when wrapping it in `:aggregation-options`."
+  {;; name to use for this aggregation in the native query instead of the default name (e.g. `count`)
+   (s/optional-key :name)         su/NonBlankString
+   ;; user-facing display name for this aggregation instead of the default one
+   (s/optional-key :display-name) su/NonBlankString})
 
-(def NamedAggregationOptions
-  "Schema for optional options map for the `:named` aggregation clause."
-  ;; whether the supplied name should be used as the user-facing display name of the aggregation as well. `true` by
-  ;; default -- this is what we want to do if the `:named` clause was generated in the FE with a user-supplied name.
-  ;; If this clause is used internally to deduplicate/uniquify aggregation names (e.g. `sum` and `sum_2`, we should
-  ;; set this to `false` so we can try to come up with a good name for the aggregation it wraps (e.g. `sum of My
-  ;; Field`)
-  {(s/optional-key :use-as-display-name?) s/Bool}) ; default true
-
-(defclause named
-  aggregation      UnnamedAggregation
-  aggregation-name su/NonBlankString
-  options          (optional NamedAggregationOptions))
+(defclause aggregation-options
+  aggregation UnnamedAggregation
+  options     AggregationOptions)
 
 (def Aggregation
   "Schema for anything that is a valid `:aggregation` clause."
-  (s/if (partial is-clause? :named)
-    named
+  (s/if (partial is-clause? :aggregation-options)
+    aggregation-options
     UnnamedAggregation))
 
 

--- a/src/metabase/mbql/util.clj
+++ b/src/metabase/mbql/util.clj
@@ -482,39 +482,58 @@
   [names :- [s/Str]]
   (map (unique-name-generator) names))
 
-(def ^:private NamedAggregationsWithUniqueNames
-  (s/constrained [mbql.s/named] #(distinct? (map last %)) "sequence of named aggregations with unique names"))
+(def ^:private NamedAggregation
+  (s/constrained
+   mbql.s/aggregation-options
+   :name
+   "`:aggregation-options` with a `:name`"))
 
-(s/defn uniquify-named-aggregations :- NamedAggregationsWithUniqueNames
+(def ^:private UniquelyNamedAggregations
+  (s/constrained
+   [NamedAggregation]
+   (fn [clauses]
+     (distinct? (for [[_ _ {ag-name :name}] clauses]
+                  ag-name)))
+   "sequence of named aggregations with unique names"))
+
+(s/defn uniquify-named-aggregations :- UniquelyNamedAggregations
   "Make the names of a sequence of named aggregations unique by adding suffixes such as `_2`."
-  [named-aggregations :- [mbql.s/named]]
-  (map (fn [original-clause unique-name]
-         (assoc (vec original-clause) 2 unique-name))
-       named-aggregations
-       (uniquify-names
-        (map #(nth % 2) named-aggregations))))
+  [named-aggregations :- [NamedAggregation]]
+  (let [unique-names (uniquify-names
+                      (for [[_ wrapped-ag {ag-name :name}] named-aggregations]
+                        ag-name))]
+    (map
+     (fn [[_ wrapped-ag options] unique-name]
+       [:aggregation-options wrapped-ag (assoc options :name unique-name)])
+     named-aggregations
+     unique-names)))
 
-(s/defn pre-alias-aggregations :- [mbql.s/named]
-  "Wrap every aggregation clause in a `:named` clause, using the name returned by `(aggregation->name-fn ag-clause)`
-  as names for any clauses that are not already wrapped in `:name`.
+(s/defn pre-alias-aggregations :- [NamedAggregation]
+  "Wrap every aggregation clause in an `:aggregation-options` clause, using the name returned
+  by `(aggregation->name-fn ag-clause)` as names for any clauses that do not already have a `:name` in
+  `:aggregation-options`.
 
-    (pre-alias-aggregations annotate/aggregation-name [[:count] [:count] [:named [:sum] \"Sum-41\"]])
-    ;; -> [[:named [:count] \"count\"]
-           [:named [:count] \"count\"]
-           [:named [:sum [:field-id 1]] \"Sum-41\"]]
+    (pre-alias-aggregations annotate/aggregation-name
+     [[:count] [:count] [:aggregation-options [:sum [:field-id 1] {:name \"Sum-41\"}]])
+    ;; -> [[:aggregation-options [:count] {:name \"count\"}]
+           [:aggregation-options [:count] {:name \"count\"}]
+           [:aggregation-options [:sum [:field-id 1]] {:name \"Sum-41\"}]]
 
   Most often, `aggregation->name-fn` will be something like `annotate/aggregation-name`, but for purposes of keeping
   the `metabase.mbql` module seperate from the `metabase.query-processor` code we'll let you pass that in yourself."
   {:style/indent 1}
   [aggregation->name-fn :- (s/pred fn?), aggregations :- [mbql.s/Aggregation]]
   (replace aggregations
-    :named
+    [:aggregation-options _ (_ :guard :name)]
     &match
 
-    [(_ :guard keyword?) & _]
-    [:named &match (aggregation->name-fn &match) {:use-as-display-name? false}]))
+    [:aggregation-options wrapped-ag options]
+    [:aggregation-options wrapped-ag (assoc options :name (aggregation->name-fn wrapped-ag))]
 
-(s/defn pre-alias-and-uniquify-aggregations :- NamedAggregationsWithUniqueNames
+    [(_ :guard keyword?) & _]
+    [:aggregation-options &match {:name (aggregation->name-fn &match)}]))
+
+(s/defn pre-alias-and-uniquify-aggregations :- UniquelyNamedAggregations
   "Wrap every aggregation clause in a `:named` clause with a unique name. Combines `pre-alias-aggregations` with
   `uniquify-named-aggregations`."
   {:style/indent 1}

--- a/test/metabase/mbql/util_test.clj
+++ b/test/metabase/mbql/util_test.clj
@@ -585,27 +585,29 @@
   (mbql.u/uniquify-names ["count" "sum" "count" "count"]))
 
 (expect
-  [[:named [:count] "count"]
-   [:named [:sum [:field-id 1]] "sum"]
-   [:named [:count] "count_2"]
-   [:named [:count] "count_3"]]
-  (mbql.u/uniquify-named-aggregations [[:named [:count] "count"]
-                                       [:named [:sum [:field-id 1]] "sum"]
-                                       [:named [:count] "count"]
-                                       [:named [:count] "count"]]))
+ [[:aggregation-options [:count] {:name "count"}]
+  [:aggregation-options [:sum [:field-id 1]] {:name "sum"}]
+  [:aggregation-options [:count] {:name "count_2"}]
+  [:aggregation-options [:count] {:name "count_3"}]]
+ (mbql.u/uniquify-named-aggregations
+  [[:aggregation-options [:count] {:name "count"}]
+   [:aggregation-options [:sum [:field-id 1]] {:name "sum"}]
+   [:aggregation-options [:count] {:name "count"}]
+   [:aggregation-options [:count] {:name "count"}]]))
 
 ;; what if we try to trick it by using a name it would have generated?
 (expect
-  ["count" "count_2" "count_2_2"]
-  (mbql.u/uniquify-names ["count" "count" "count_2"]))
+ ["count" "count_2" "count_2_2"]
+ (mbql.u/uniquify-names ["count" "count" "count_2"]))
 
 (expect
-  [[:named [:count] "count"]
-   [:named [:count] "count_2"]
-   [:named [:count] "count_2_2"]]
-  (mbql.u/uniquify-named-aggregations [[:named [:count] "count"]
-                                       [:named [:count] "count"]
-                                       [:named [:count] "count_2"]]))
+ [[:aggregation-options [:count] {:name "count"}]
+  [:aggregation-options [:count] {:name "count_2"}]
+  [:aggregation-options [:count] {:name "count_2_2"}]]
+ (mbql.u/uniquify-named-aggregations
+  [[:aggregation-options [:count] {:name "count"}]
+   [:aggregation-options [:count] {:name "count"}]
+   [:aggregation-options [:count] {:name "count_2"}]]))
 
 ;; for wacky DBMSes like SQLServer that return blank column names sometimes let's make sure we handle those without
 ;; exploding
@@ -618,44 +620,44 @@
   (name ag-name))
 
 (expect
-  [[:named [:sum [:field-id 1]]   "sum"   {:use-as-display-name? false}]
-   [:named [:count [:field-id 1]] "count" {:use-as-display-name? false}]
-   [:named [:sum [:field-id 1]]   "sum"   {:use-as-display-name? false}]
-   [:named [:avg [:field-id 1]]   "avg"   {:use-as-display-name? false}]
-   [:named [:sum [:field-id 1]]   "sum"   {:use-as-display-name? false}]
-   [:named [:min [:field-id 1]]   "min"   {:use-as-display-name? false}]]
-  (mbql.u/pre-alias-aggregations simple-ag->name
-    [[:sum [:field-id 1]]
-     [:count [:field-id 1]]
-     [:sum [:field-id 1]]
-     [:avg [:field-id 1]]
-     [:sum [:field-id 1]]
-     [:min [:field-id 1]]]))
+ [[:aggregation-options [:sum [:field-id 1]]   {:name "sum"}]
+  [:aggregation-options [:count [:field-id 1]] {:name "count"}]
+  [:aggregation-options [:sum [:field-id 1]]   {:name "sum"}]
+  [:aggregation-options [:avg [:field-id 1]]   {:name "avg"}]
+  [:aggregation-options [:sum [:field-id 1]]   {:name "sum"}]
+  [:aggregation-options [:min [:field-id 1]]   {:name "min"}]]
+ (mbql.u/pre-alias-aggregations simple-ag->name
+   [[:sum [:field-id 1]]
+    [:count [:field-id 1]]
+    [:sum [:field-id 1]]
+    [:avg [:field-id 1]]
+    [:sum [:field-id 1]]
+    [:min [:field-id 1]]]))
 
 ;; we shouldn't change the name of ones that are already named
 (expect
-  [[:named [:sum [:field-id 1]]   "sum"   {:use-as-display-name? false}]
-   [:named [:count [:field-id 1]] "count" {:use-as-display-name? false}]
-   [:named [:sum [:field-id 1]]   "sum"   {:use-as-display-name? false}]
-   [:named [:avg [:field-id 1]]   "avg"   {:use-as-display-name? false}]
-   [:named [:sum [:field-id 1]]   "sum_2"]
-   [:named [:min [:field-id 1]]   "min"   {:use-as-display-name? false}]]
-  (mbql.u/pre-alias-aggregations simple-ag->name
-    [[:sum [:field-id 1]]
-     [:count [:field-id 1]]
-     [:sum [:field-id 1]]
-     [:avg [:field-id 1]]
-     [:named [:sum [:field-id 1]] "sum_2"]
-     [:min [:field-id 1]]]))
+ [[:aggregation-options [:sum [:field-id 1]]   {:name "sum"}]
+  [:aggregation-options [:count [:field-id 1]] {:name "count"}]
+  [:aggregation-options [:sum [:field-id 1]]   {:name "sum"}]
+  [:aggregation-options [:avg [:field-id 1]]   {:name "avg"}]
+  [:aggregation-options [:sum [:field-id 1]]   {:name "sum_2"}]
+  [:aggregation-options [:min [:field-id 1]]   {:name "min"}]]
+ (mbql.u/pre-alias-aggregations simple-ag->name
+   [[:sum [:field-id 1]]
+    [:count [:field-id 1]]
+    [:sum [:field-id 1]]
+    [:avg [:field-id 1]]
+    [:aggregation-options [:sum [:field-id 1]] {:name "sum_2"}]
+    [:min [:field-id 1]]]))
 
 ;; ok, can we do the same thing as the tests above but make those names *unique* at the same time?
 (expect
-  [[:named [:sum [:field-id 1]]   "sum"   {:use-as-display-name? false}]
-   [:named [:count [:field-id 1]] "count" {:use-as-display-name? false}]
-   [:named [:sum [:field-id 1]]   "sum_2" {:use-as-display-name? false}]
-   [:named [:avg [:field-id 1]]   "avg"   {:use-as-display-name? false}]
-   [:named [:sum [:field-id 1]]   "sum_3" {:use-as-display-name? false}]
-   [:named [:min [:field-id 1]]   "min"   {:use-as-display-name? false}]]
+ [[:aggregation-options [:sum [:field-id 1]]   {:name "sum"}  ]
+  [:aggregation-options [:count [:field-id 1]] {:name "count"}]
+  [:aggregation-options [:sum [:field-id 1]]   {:name "sum_2"}]
+  [:aggregation-options [:avg [:field-id 1]]   {:name "avg"}  ]
+  [:aggregation-options [:sum [:field-id 1]]   {:name "sum_3"}]
+  [:aggregation-options [:min [:field-id 1]]   {:name "min"}  ]]
   (mbql.u/pre-alias-and-uniquify-aggregations simple-ag->name
     [[:sum [:field-id 1]]
      [:count [:field-id 1]]
@@ -665,35 +667,41 @@
      [:min [:field-id 1]]]))
 
 (expect
-  [[:named [:sum [:field-id 1]]   "sum"     {:use-as-display-name? false}]
-   [:named [:count [:field-id 1]] "count"   {:use-as-display-name? false}]
-   [:named [:sum [:field-id 1]]   "sum_2"   {:use-as-display-name? false}]
-   [:named [:avg [:field-id 1]]   "avg"     {:use-as-display-name? false}]
-   [:named [:sum [:field-id 1]]   "sum_2_2"]
-   [:named [:min [:field-id 1]]   "min"     {:use-as-display-name? false}]]
-  (mbql.u/pre-alias-and-uniquify-aggregations simple-ag->name
-    [[:sum [:field-id 1]]
-     [:count [:field-id 1]]
-     [:sum [:field-id 1]]
-     [:avg [:field-id 1]]
-     [:named [:sum [:field-id 1]] "sum_2"]
-     [:min [:field-id 1]]]))
-
-;; `pre-alias-and-uniquify-aggregations` shouldn't stomp over existing options
-(expect
- [[:named [:sum [:field-id 1]]   "sum"     {:use-as-display-name? false}]
-  [:named [:count [:field-id 1]] "count"   {:use-as-display-name? false}]
-  [:named [:sum [:field-id 1]]   "sum_2"   {:use-as-display-name? true}]
-  [:named [:avg [:field-id 1]]   "avg"     {:use-as-display-name? true}]
-  [:named [:sum [:field-id 1]]   "sum_2_2" {:use-as-display-name? true}]
-  [:named [:min [:field-id 1]]   "min"     {:use-as-display-name? false}]]
+ [[:aggregation-options [:sum [:field-id 1]]   {:name "sum"}]
+  [:aggregation-options [:count [:field-id 1]] {:name "count"}]
+  [:aggregation-options [:sum [:field-id 1]]   {:name "sum_2"}]
+  [:aggregation-options [:avg [:field-id 1]]   {:name "avg"}]
+  [:aggregation-options [:sum [:field-id 1]]   {:name "sum_2_2"}]
+  [:aggregation-options [:min [:field-id 1]]   {:name "min"}]]
  (mbql.u/pre-alias-and-uniquify-aggregations simple-ag->name
    [[:sum [:field-id 1]]
     [:count [:field-id 1]]
-    [:named [:sum [:field-id 1]] "sum"   {:use-as-display-name? true}]
-    [:named [:avg [:field-id 1]] "avg"   {:use-as-display-name? true}]
-    [:named [:sum [:field-id 1]] "sum_2" {:use-as-display-name? true}]
+    [:sum [:field-id 1]]
+    [:avg [:field-id 1]]
+    [:aggregation-options [:sum [:field-id 1]] {:name "sum_2"}]
     [:min [:field-id 1]]]))
+
+;; if `:aggregation-options` only specifies `:display-name` it should still a new `:name`.
+;; `pre-alias-and-uniquify-aggregations` shouldn't stomp over display name
+(expect
+ [[:aggregation-options [:sum [:field-id 1]] {:name "sum"}]
+  [:aggregation-options [:sum [:field-id 1]] {:name "sum_2"}]
+  [:aggregation-options [:sum [:field-id 1]] {:display-name "Sum of Field 1", :name "sum_3"}]]
+ (mbql.u/pre-alias-and-uniquify-aggregations simple-ag->name
+   [[:sum [:field-id 1]]
+    [:sum [:field-id 1]]
+    [:aggregation-options [:sum [:field-id 1]] {:display-name "Sum of Field 1"}]]))
+
+;; if both are specified, `display-name` should still be propogated
+(expect
+ [[:aggregation-options [:sum [:field-id 1]] {:name "sum"}]
+  [:aggregation-options [:sum [:field-id 1]] {:name "sum_2"}]
+  [:aggregation-options [:sum [:field-id 1]] {:name "sum_2_2", :display_name "Sum of Field 1"}]]
+ (mbql.u/pre-alias-and-uniquify-aggregations simple-ag->name
+   [[:sum [:field-id 1]]
+    [:sum [:field-id 1]]
+    [:aggregation-options [:sum [:field-id 1]] {:name "sum_2", :display_name "Sum of Field 1"}]]))
+
 
 ;;; --------------------------------------------- query->max-rows-limit ----------------------------------------------
 


### PR DESCRIPTION
This will future-proof us a bit by letting us add new options in the future without having to define new clauses.

Required for powering some new features in Metabase 0.33.0. 