### PR TITLE
Util function fixes; enable schemas in dev & tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metabase/mbql "1.3.0"
+(defproject metabase/mbql "1.3.1"
   :description "Shared things used across several Metabase projects, such as i18n and config."
   :url "https://github.com/metabase/mbql"
   :min-lein-version "2.5.0"
@@ -31,7 +31,9 @@
 
     :injections
     [(require 'expectations)
-     ((resolve 'expectations/disable-run-on-shutdown))]
+     (#'expectations/disable-run-on-shutdown)
+     (require 'schema.core)
+     (schema.core/set-fn-validation! true)]
 
     :jvm-opts
     ["-Xverify:none"]}

--- a/src/metabase/mbql/schema.clj
+++ b/src/metabase/mbql/schema.clj
@@ -636,8 +636,8 @@
   implicit joins; for explicit joins, you *must* specify `:alias` yourself; you can then reference Fields by using a
   `:joined-field` clause, e.g.
 
-    [:joined-field \"my_join_alias\" [:field-id 1]]                 ; for joins against other Tabless
-    [:joined-field \"my_join_alias\" [:field-literal \"my_field\"]] ; for joins against nested queries"
+    [:joined-field \"my_join_alias\" [:field-id 1]]                                ; for joins against other Tabless
+    [:joined-field \"my_join_alias\" [:field-literal \"my_field\" :field/Integer]] ; for joins against nested queries"
   (->
    {;; *What* to JOIN. Self-joins can be done by using the same `:source-table` as in the query where this is specified.
     ;; YOU MUST SUPPLY EITHER `:source-table` OR `:source-query`, BUT NOT BOTH!

--- a/src/metabase/mbql/util.clj
+++ b/src/metabase/mbql/util.clj
@@ -485,15 +485,15 @@
 (def ^:private NamedAggregation
   (s/constrained
    mbql.s/aggregation-options
-   :name
+   #(:name (nth % 2))
    "`:aggregation-options` with a `:name`"))
 
 (def ^:private UniquelyNamedAggregations
   (s/constrained
    [NamedAggregation]
    (fn [clauses]
-     (distinct? (for [[_ _ {ag-name :name}] clauses]
-                  ag-name)))
+     (apply distinct? (for [[_ _ {ag-name :name}] clauses]
+                        ag-name)))
    "sequence of named aggregations with unique names"))
 
 (s/defn uniquify-named-aggregations :- UniquelyNamedAggregations

--- a/test/metabase/mbql/util_test.clj
+++ b/test/metabase/mbql/util_test.clj
@@ -696,11 +696,11 @@
 (expect
  [[:aggregation-options [:sum [:field-id 1]] {:name "sum"}]
   [:aggregation-options [:sum [:field-id 1]] {:name "sum_2"}]
-  [:aggregation-options [:sum [:field-id 1]] {:name "sum_2_2", :display_name "Sum of Field 1"}]]
+  [:aggregation-options [:sum [:field-id 1]] {:name "sum_2_2", :display-name "Sum of Field 1"}]]
  (mbql.u/pre-alias-and-uniquify-aggregations simple-ag->name
    [[:sum [:field-id 1]]
     [:sum [:field-id 1]]
-    [:aggregation-options [:sum [:field-id 1]] {:name "sum_2", :display_name "Sum of Field 1"}]]))
+    [:aggregation-options [:sum [:field-id 1]] {:name "sum_2", :display-name "Sum of Field 1"}]]))
 
 
 ;;; --------------------------------------------- query->max-rows-limit ----------------------------------------------
@@ -806,9 +806,11 @@
   [:joined-field "a" [:field-id 10]]
   (mbql.u/->joined-field "a" [:field-id 10]))
 
+(derive :type/Integer :type/*)
+
 (expect
-  [:joined-field "a" [:field-literal "ABC" :type/Integer]]
-  (mbql.u/->joined-field "a" [:field-literal "ABC" :type/Integer]))
+ [:joined-field "a" [:field-literal "ABC" :type/Integer]]
+ (mbql.u/->joined-field "a" [:field-literal "ABC" :type/Integer]))
 
 (expect
   [:datetime-field [:joined-field "a" [:field-id 1]] :month]


### PR DESCRIPTION
Schemas attached to functions aren't enforced globally by default like they are in Metabase core so some tests were passing when they shouldn't have been. This PR enables schema checks in dev/test and fixes a few bugs in util functions 