### PR TITLE
Adds padded option to relative-datetime for BETWEEN SQL optimizations

### DIFF
--- a/src/metabase/mbql/normalize.clj
+++ b/src/metabase/mbql/normalize.clj
@@ -119,10 +119,21 @@
   ;; Normalize a `relative-datetime` clause. `relative-datetime` comes in two flavors:
   ;;
   ;;   [:relative-datetime :current]
-  ;;   [:relative-datetime -10 :day] ; amount & unit"
-  [[_ amount unit]]
-  (if unit
-    [:relative-datetime amount (mbql.u/normalize-token unit)]
+  ;;   [:relative-datetime :current {:padded? false}]
+  ;;   [:relative-datetime -10 :day]
+  ;;   [:relative-datetime -10 :day {:padded? false}] ; amount & unit"
+  [[_ amount unitOrOptions options]]
+  (cond
+    (and unitOrOptions options)
+    [:relative-datetime amount (mbql.u/normalize-token unitOrOptions) options]
+
+    (and unitOrOptions (map? unitOrOptions)) ;; options
+    [:relative-datetime :current unitOrOptions]
+
+    unitOrOptions ;; unit
+    [:relative-datetime amount (mbql.u/normalize-token unitOrOptions)]
+
+    :else
     [:relative-datetime :current]))
 
 (defmethod normalize-mbql-clause-tokens :interval

--- a/src/metabase/mbql/normalize.clj
+++ b/src/metabase/mbql/normalize.clj
@@ -122,16 +122,16 @@
   ;;   [:relative-datetime :current {:padded? false}]
   ;;   [:relative-datetime -10 :day]
   ;;   [:relative-datetime -10 :day {:padded? false}] ; amount & unit"
-  [[_ amount unitOrOptions options]]
+  [[_ amount unit-or-options options]]
   (cond
-    (and unitOrOptions options)
-    [:relative-datetime amount (mbql.u/normalize-token unitOrOptions) options]
+    (and unit-or-options options)
+    [:relative-datetime amount (mbql.u/normalize-token unit-or-options) options]
 
-    (and unitOrOptions (map? unitOrOptions)) ;; options
-    [:relative-datetime :current unitOrOptions]
+    (map? unit-or-options) ;; options
+    [:relative-datetime :current unit-or-options]
 
-    unitOrOptions ;; unit
-    [:relative-datetime amount (mbql.u/normalize-token unitOrOptions)]
+    unit-or-options ;; unit
+    [:relative-datetime amount (mbql.u/normalize-token unit-or-options)]
 
     :else
     [:relative-datetime :current]))

--- a/src/metabase/mbql/schema.clj
+++ b/src/metabase/mbql/schema.clj
@@ -47,6 +47,9 @@
    (apply s/enum #{:default :minute :hour :day :week :month :quarter :year})
    "relative-datetime-unit"))
 
+(def ^:private RelativeDatetimeOptions
+  {(s/optional-key :padded?) s/Bool}) ; default false
+
 (defn- can-parse-iso-8601? [^DateTimeFormatter formatter, ^String s]
   (when (string? s)
     (try
@@ -81,9 +84,19 @@
    "valid ISO-8601 datetime, date, or time string literal"))
 
 ;; TODO - `unit` is not allowed if `n` is `current`
-(defclause relative-datetime
-  n    (s/cond-pre (s/eq :current) s/Int)
-  unit (optional RelativeDatetimeUnit))
+(def relative-datetime
+  "Schema for a `relative-datetime` clause."
+  (s/conditional
+   (every-pred sequential? #(core/= :current (second %)))
+   [(s/one (s/eq :relative-datetime) "clause name")
+    (s/one (s/eq :current) "current")
+    (s/optional RelativeDatetimeOptions "options")]
+
+   :else
+   [(s/one (s/eq :relative-datetime) "clause name")
+    (s/one s/Int "n")
+    (s/one RelativeDatetimeUnit "unit")
+    (s/optional RelativeDatetimeOptions "options")]))
 
 (defclause interval
   n    s/Int

--- a/test/metabase/mbql/normalize_test.clj
+++ b/test/metabase/mbql/normalize_test.clj
@@ -57,6 +57,14 @@
   {:order-by [[:desc [:field-literal "SALES/TAX" :type/Number]]]}
   (#'normalize/normalize-tokens {:order-by [[:desc ["field_literal" :SALES/TAX "type/Number"]]]}))
 
+(expect
+ {:filter [:between [:field-id 10] [:relative-datetime -10 :day {:padded? true}] [:relative-datetime :current]]}
+  (#'normalize/normalize-tokens
+    {:filter ["BETWEEN"
+               ["field-id" 10]
+               ["relative-datetime" -10 "day" {:padded? true}]
+               ["relative-datetime" :current]]}))
+
 
 ;;; -------------------------------------------------- aggregation ---------------------------------------------------
 


### PR DESCRIPTION
This adds `options` argument to the `relative-datetime` clause and specifically a `padded?` option that should tell underlying drivers not to truncate dates to the specified unit but to fill the part that is not part of the chosen unit with zeroes.

Previous PR #1 