### PR TITLE
Fix normalization of params

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metabase/mbql "1.3.5-SNAPSHOT"
+(defproject metabase/mbql "1.3.5"
   :description "Shared things used across several Metabase projects, such as i18n and config."
   :url "https://github.com/metabase/mbql"
   :min-lein-version "2.5.0"

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
             :url "https://raw.githubusercontent.com/metabase/mbql/master/LICENSE"}
 
   :aliases
-  {"test"                      ["with-profile" "+expectations" "expectations"]
+  {"test"                      ["with-profile" "+test" "test"]
    "bikeshed"                  ["with-profile" "+bikeshed" "bikeshed" "--max-line-length" "120"]
    "check-namespace-decls"     ["with-profile" "+check-namespace-decls" "check-namespace-decls"]
    "eastwood"                  ["with-profile" "+eastwood" "eastwood"]
@@ -27,19 +27,19 @@
   {:dev
    {:dependencies
     [[org.clojure/clojure "1.10.1"]
-     [expectations "2.2.0-beta2"]]
+     [pjstadig/humane-test-output "0.9.0"]]
 
     :injections
-    [(require 'expectations)
-     (#'expectations/disable-run-on-shutdown)
-     (require 'schema.core)
-     (schema.core/set-fn-validation! true)]
+    [(require 'schema.core)
+     (schema.core/set-fn-validation! true)
+     (require 'pjstadig.humane-test-output)
+     (pjstadig.humane-test-output/activate!)]
 
     :jvm-opts
     ["-Xverify:none"]}
 
-   :expectations
-   {:plugins [[lein-expectations "0.0.8" :exclusions [expectations]]]}
+   :test
+   {}
 
    :eastwood
    {:plugins

--- a/src/metabase/mbql/normalize.clj
+++ b/src/metabase/mbql/normalize.clj
@@ -231,7 +231,8 @@
   {:type            mbql.u/normalize-token
    ;; don't normalize native queries
    :native          {:query         identity
-                     :template-tags normalize-template-tags}
+                     :template-tags normalize-template-tags
+                     :params        identity}
    :query           {:aggregation     normalize-ag-clause-tokens
                      :expressions     normalize-expressions-tokens
                      :order-by        normalize-order-by-tokens

--- a/test/expectations.clj
+++ b/test/expectations.clj
@@ -1,0 +1,10 @@
+(ns expectations
+  (:require [clojure.test :as t]))
+
+(defmacro ^:deprecated expect
+  ([actual]
+   `(expect true (boolean ~actual)))
+
+  ([expected actual]
+   `(t/deftest ~(symbol (format "expect-%s" (hash &form)))
+      (t/is (= ~expected ~actual)))))

--- a/test/metabase/mbql/normalize_test.clj
+++ b/test/metabase/mbql/normalize_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.mbql.normalize-test
-  (:require [expectations :refer [expect]]
+  (:require [clojure.test :refer :all]
+            [expectations :refer [expect]]
             [metabase.mbql.normalize :as normalize]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -385,6 +386,14 @@
   {:context nil}
   (#'normalize/normalize-tokens {:context nil}))
 
+(deftest params-normalization-test
+  (is (= {:native {:query  "SELECT * FROM venues WHERE name = ?"
+                   :params ["Red Medicine"]}}
+         (#'normalize/normalize-tokens
+          {:native {:query  "SELECT * FROM venues WHERE name = ?"
+                    :params ["Red Medicine"]}}))
+      ":native :params shouldn't get normalized."))
+
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                  CANONICALIZE                                                  |
@@ -392,8 +401,8 @@
 
 ;; Does our `wrap-implict-field-id` fn work?
 (expect
-  [:field-id 10]
-  (#'normalize/wrap-implicit-field-id 10))
+ [:field-id 10]
+ (#'normalize/wrap-implicit-field-id 10))
 
 (expect
   [:field-id 10]
@@ -410,8 +419,8 @@
 ;; Do aggregations get canonicalized properly?
 ;; field ID should get wrapped in field-id and ags should be converted to multiple ag syntax
 (expect
-  {:query {:aggregation [[:count [:field-id 10]]]}}
-  (#'normalize/canonicalize {:query {:aggregation [:count 10]}}))
+ {:query {:aggregation [[:count [:field-id 10]]]}}
+ (#'normalize/canonicalize {:query {:aggregation [:count 10]}}))
 
 ;; ag with no Field ID
 (expect

--- a/test/metabase/mbql/util_test.clj
+++ b/test/metabase/mbql/util_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.mbql.util-test
-  (:require [expectations :refer [expect]]
+  (:require [clojure.test :refer :all]
+            [expectations :refer [expect]]
             [metabase.mbql.util :as mbql.u]))
 
 ;; make sure `relative-date` works as expected
@@ -801,29 +802,24 @@
     :query       {:source-table 1}}))
 
 
-;; make sure `->joined-field` works the way it is supposed to
-(expect
-  [:joined-field "a" [:field-id 10]]
-  (mbql.u/->joined-field "a" [:field-id 10]))
-
 (derive :type/Integer :type/*)
 
-(expect
- [:joined-field "a" [:field-literal "ABC" :type/Integer]]
- (mbql.u/->joined-field "a" [:field-literal "ABC" :type/Integer]))
+(deftest joined-field-test
+  (is (= [:joined-field "a" [:field-id 10]]
+         (mbql.u/->joined-field "a" [:field-id 10])))
 
-(expect
-  [:datetime-field [:joined-field "a" [:field-id 1]] :month]
-  (mbql.u/->joined-field "a" [:datetime-field [:field-id 1] :month]))
+  (is (= [:joined-field "a" [:field-literal "ABC" :type/Integer]]
+         (mbql.u/->joined-field "a" [:field-literal "ABC" :type/Integer])))
 
-;; should throw an Exception if the Field already has an alias
-(expect
-  Exception
-  (mbql.u/->joined-field "a" [:joined-field "a" [:field-id 1]]))
+  (is (= [:datetime-field [:joined-field "a" [:field-id 1]] :month]
+         (mbql.u/->joined-field "a" [:datetime-field [:field-id 1] :month])))
 
-(expect
-  Exception
-  (mbql.u/->joined-field "a" [:datetime-field [:joined-field "a" [:field-id 1]] :month]))
+  (testing "We should throw an Exception if the Field already has an alias"
+    (is (thrown? Exception
+                 (mbql.u/->joined-field "a" [:joined-field "a" [:field-id 1]])))
+
+    (is (thrown? Exception
+                 (mbql.u/->joined-field "a" [:datetime-field [:joined-field "a" [:field-id 1]] :month])))))
 
 (expect
   (mbql.u/datetime-arithmetics? [:+ [:field-id 13] [:interval -1 :month]]))


### PR DESCRIPTION
*  Switches for using `expectations` to `clojure.test` for unit tests. Added new `expect` macro to convert existing `expect` forms to `deftest` forms; use `deftest` directly going forward 
*  Fixes normalization of `[:native :params]`.
