### PR TITLE
Move filter clause desugaring/negation logic from core MB repo

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metabase/mbql "1.3.5"
+(defproject metabase/mbql "1.3.6"
   :description "Shared things used across several Metabase projects, such as i18n and config."
   :url "https://github.com/metabase/mbql"
   :min-lein-version "2.5.0"


### PR DESCRIPTION
Seemed like since they are generic MBQL transformations they belong here rather than in Metabase proper. Also added tests for `combine-filter-clauses` and `add-filter-clause` which were missing them.