### PR TITLE
Fix normalization of map native queries

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metabase/mbql "1.4.1"
+(defproject metabase/mbql "1.4.2"
   :description "Shared things used across several Metabase projects, such as i18n and config."
   :url "https://github.com/metabase/mbql"
   :min-lein-version "2.5.0"

--- a/src/metabase/mbql/util.clj
+++ b/src/metabase/mbql/util.clj
@@ -549,16 +549,12 @@
   [[_ id]]
   (ga-id? id))
 
-(defn datetime-field?
+(defn temporal-field?
   "Is `field` used to record something date or time related, i.e. does `field` have a base type or special type that
-  derives from `:type/DateTime`?
-
-  For historical reasons `:type/Time` derivies from `:type/DateTime`, meaning this function will still return true for
-  Fields that record only time. You can use `datetime-but-not-time-field?` instead if you want to exclude time
-  Fields."
+  derives from `:type/Temporal`?"
   [field]
-  (or (isa? (:base_type field)    :type/DateTime)
-      (isa? (:special_type field) :type/DateTime)))
+  (or (isa? (:base_type field)    :type/Temporal)
+      (isa? (:special_type field) :type/Temporal)))
 
 (defn time-field?
   "Is `field` used to record a time of day (e.g. hour/minute/second), but not the date itself? i.e. does `field` have a
@@ -567,11 +563,11 @@
   (or (isa? (:base_type field)    :type/Time)
       (isa? (:special_type field) :type/Time)))
 
-(defn datetime-but-not-time-field?
-  "Is `field` used to record a specific moment in time, i.e. does `field` have a base type or special type that derives
-  from `:type/DateTime` but not `:type/Time`?"
+(defn temporal-but-not-time-field?
+  "Does `field` have a base type or special type that derives from `:type/Temporal`, but not `:type/Time`? (i.e., is
+  Field a Date or DateTime?)"
   [field]
-  (and (datetime-field? field)
+  (and (temporal-field? field)
        (not (time-field? field))))
 
 (defn datetime-arithmetics?

--- a/test/metabase/mbql/normalize_test.clj
+++ b/test/metabase/mbql/normalize_test.clj
@@ -1071,6 +1071,6 @@
 
                                  "native source query in join"
                                  {:query {:joins [{:source-query native-source-query}]}}}]
-          (is (= query
-                 (normalize/normalize query))
-              message))))))
+          (testing message
+            (is (= query
+                   (normalize/normalize query)))))))))


### PR DESCRIPTION
Fix the way native queries that are maps (e.g., MongoDB or Druid queries) are normalized – previously, nil keys were removed from maps and keys could get normalized if the query was a source query